### PR TITLE
chore(release): prepare v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: find
-        uses: bendrucker/find-terraform-modules@v1
+        uses: bendrucker/find-terraform-modules@v2
         with:
           working-directory: ./modules
     outputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "find-terraform-modules",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "find-terraform-modules",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-terraform-modules",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": true,
   "description": "GitHub Action that finds all Terraform module directories in a monorepo. Results can be passed to matrix jobs or looped in other steps.",
   "type": "module",


### PR DESCRIPTION
Prepares the repository for the v2.0.0 release.

## Changes

- Bumps `package.json` and `package-lock.json` to `2.0.0`.
- Updates the `README.md` usage example to reference `@v2`.
